### PR TITLE
feat(anchor-cli): cargo shim with set nightly rust

### DIFF
--- a/patches/anchor-cli/0.30.1.patch
+++ b/patches/anchor-cli/0.30.1.patch
@@ -114,31 +114,18 @@ index 9befe845..7a9ae066 100644
          }
      }
 diff --git a/idl/src/build.rs b/idl/src/build.rs
-index 96dc3db2..d28a34b5 100644
+index 96dc3db2..02d754c9 100644
 --- a/idl/src/build.rs
 +++ b/idl/src/build.rs
-@@ -60,16 +60,14 @@ pub fn build_idl(
- 
- /// Build IDL.
- fn build(program_path: &Path, resolution: bool, skip_lint: bool, no_docs: bool) -> Result<Idl> {
--    // `nightly` toolchain is currently required for building the IDL.
--    let toolchain = std::env::var("RUSTUP_TOOLCHAIN")
--        .map(|toolchain| format!("+{}", toolchain))
--        .unwrap_or_else(|_| "+nightly".to_string());
-+    let mut command = Command::new("cargo");
+@@ -65,8 +65,6 @@ fn build(program_path: &Path, resolution: bool, skip_lint: bool, no_docs: bool)
+         .map(|toolchain| format!("+{}", toolchain))
+         .unwrap_or_else(|_| "+nightly".to_string());
  
 -    install_toolchain_if_needed(&toolchain)?;
-+    if let Ok(toolchain) = std::env::var("RUSTUP_TOOLCHAIN") {
-+        command.arg(&format!("+{}", toolchain));
-+    }
- 
--    let output = Command::new("cargo")
-+    let output = command
+-
+     let output = Command::new("cargo")
          .args([
--            &toolchain,
-             "test",
-             "__anchor_private_print_idl",
-             "--features",
+             &toolchain,
 @@ -202,23 +200,6 @@ fn build(program_path: &Path, resolution: bool, skip_lint: bool, no_docs: bool)
      idl.ok_or_else(|| anyhow!("IDL doesn't exist"))
  }

--- a/patches/anchor-cli/0.31.0.patch
+++ b/patches/anchor-cli/0.31.0.patch
@@ -152,31 +152,18 @@ index 3404b032..34b08dac 100644
          }
      }
 diff --git a/idl/src/build.rs b/idl/src/build.rs
-index ccd89745..a4edf8a5 100644
+index ccd89745..83028bf4 100644
 --- a/idl/src/build.rs
 +++ b/idl/src/build.rs
-@@ -138,15 +138,12 @@ fn build(
-     no_docs: bool,
-     cargo_args: &[String],
- ) -> Result<Idl> {
--    // `nightly` toolchain is currently required for building the IDL.
--    let toolchain = std::env::var("RUSTUP_TOOLCHAIN")
--        .map(|toolchain| format!("+{}", toolchain))
--        .unwrap_or_else(|_| "+nightly".to_string());
--
+@@ -143,7 +143,6 @@ fn build(
+         .map(|toolchain| format!("+{}", toolchain))
+         .unwrap_or_else(|_| "+nightly".to_string());
+ 
 -    install_toolchain_if_needed(&toolchain)?;
--    let output = Command::new("cargo")
-+    let mut command = Command::new("cargo");
-+    if let Ok(toolchain) = std::env::var("RUSTUP_TOOLCHAIN") {
-+        command.arg(&format!("+{}", toolchain));
-+    }
-+    let output = command
+     let output = Command::new("cargo")
          .args([
--            &toolchain,
-             "test",
-             "__anchor_private_print_idl",
-             "--features",
-@@ -283,23 +280,6 @@ fn build(
+             &toolchain,
+@@ -283,23 +282,6 @@ fn build(
      idl.ok_or_else(|| anyhow!("IDL doesn't exist"))
  }
  

--- a/patches/anchor-cli/0.31.1.patch
+++ b/patches/anchor-cli/0.31.1.patch
@@ -152,35 +152,18 @@ index 3404b032..34b08dac 100644
          }
      }
 diff --git a/idl/src/build.rs b/idl/src/build.rs
-index ccd89745..3c958377 100644
+index ccd89745..83028bf4 100644
 --- a/idl/src/build.rs
 +++ b/idl/src/build.rs
-@@ -139,14 +139,18 @@ fn build(
-     cargo_args: &[String],
- ) -> Result<Idl> {
-     // `nightly` toolchain is currently required for building the IDL.
--    let toolchain = std::env::var("RUSTUP_TOOLCHAIN")
--        .map(|toolchain| format!("+{}", toolchain))
--        .unwrap_or_else(|_| "+nightly".to_string());
-+    let cargo_path = std::env::var("RUST_NIGHTLY_BIN")
-+        .map(|bin| format!("{}/cargo", bin))
-+        .unwrap_or_else(|_| "cargo".to_string());
+@@ -143,7 +143,6 @@ fn build(
+         .map(|toolchain| format!("+{}", toolchain))
+         .unwrap_or_else(|_| "+nightly".to_string());
  
 -    install_toolchain_if_needed(&toolchain)?;
--    let output = Command::new("cargo")
-+    eprintln!("Cargo at {}", cargo_path);
-+
-+    let mut command = Command::new(cargo_path);
-+    if let Ok(toolchain) = std::env::var("RUSTUP_TOOLCHAIN") {
-+        command.arg(&format!("+{}", toolchain));
-+    }
-+    let output = command
+     let output = Command::new("cargo")
          .args([
--            &toolchain,
-             "test",
-             "__anchor_private_print_idl",
-             "--features",
-@@ -283,23 +287,6 @@ fn build(
+             &toolchain,
+@@ -283,23 +282,6 @@ fn build(
      idl.ok_or_else(|| anyhow!("IDL doesn't exist"))
  }
  


### PR DESCRIPTION
Hey, I saw the issue with the nightly usage, and personally I prefer not having to use nightly as well when possible.

The current solution would force anchor to use nightly when we had an override, but I thought it would instead be nicer to provide both toolchains to anchor and let it pick the one it wants, so for example during IDL it will use nightly, but during normal build it would use stable.

To do that, I created a small shim script that acts in a similar way as the actual `cargo` binary, where the right toolchain is dispatched based on the first argument, in this case if omitted it would use stable and when `+nightly` is specified it would use the nightly toolchain we configured it for.

This is useful for multi-version compatibility: in this case 0.30.1 still makes use of the old API, therefore having a nightly toolchain which is compatible allows users (like me) to still make use of this specific anchor version. In the newer versions, the usage was patched so "latest" nightly is selected.

I also edited the patches so that `+nightly` is set normally by the IDL build step (since it would use the shim), and we only skip the toolchain installation phase.