### PR TITLE
Update to Solana v2.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1745454774,
-        "narHash": "sha256-oLvmxOnsEKGtwczxp/CwhrfmQUG2ym24OMWowcoRhH8=",
+        "lastModified": 1755993354,
+        "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "efd36682371678e2b6da3f108fdb5c613b3ec598",
+        "rev": "25bd41b24426c7734278c2ff02e53258851db914",
         "type": "github"
       },
       "original": {
@@ -50,17 +50,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731603435,
-        "narHash": "sha256-CqCX4JG7UiHvkrBTpYC3wcEurvbtTADLbo3Ns2CEoL8=",
+        "lastModified": 1748026580,
+        "narHash": "sha256-rWtXrcIzU5wm/C8F9LWvUfBGu5U5E7cFzPYT1pHIJaQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296",
+        "rev": "11cb3517b3af6af300dd6c055aeda73c9bf52c48",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296",
+        "rev": "11cb3517b3af6af300dd6c055aeda73c9bf52c48",
         "type": "github"
       }
     },
@@ -95,17 +95,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1746239644,
-        "narHash": "sha256-wMvMBMlpS1H8CQdSSgpLeoCWS67ciEkN/GVCcwk7Apc=",
+        "lastModified": 1756607787,
+        "narHash": "sha256-ciwAdgtlAN1PCaidWK6RuWsTBL8DVuyDCGM+X3ein5Q=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bd32e88bef6da0e021a42fb4120a8df2150e9b8c",
+        "rev": "f46d294b87ebb9f7124f1ce13aa2a5f5acc0f3eb",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "bd32e88bef6da0e021a42fb4120a8df2150e9b8c",
+        "rev": "f46d294b87ebb9f7124f1ce13aa2a5f5acc0f3eb",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,11 @@
 {
   description = "Solana development setup with Nix.";
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296";
+    nixpkgs.url = "github:nixos/nixpkgs/11cb3517b3af6af300dd6c055aeda73c9bf52c48";
     flake-parts.url = "github:hercules-ci/flake-parts/f4330d22f1c5d2ba72d3d22df5597d123fdb60a9";
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
     rust-overlay = {
-      url = "github:oxalica/rust-overlay/bd32e88bef6da0e021a42fb4120a8df2150e9b8c";
+      url = "github:oxalica/rust-overlay/f46d294b87ebb9f7124f1ce13aa2a5f5acc0f3eb";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     crane.url = "github:ipetkov/crane";

--- a/solana-cli.nix
+++ b/solana-cli.nix
@@ -6,7 +6,7 @@
   udev,
   protobuf,
   libcxx,
-  rocksdb_8_11,
+  rocksdb,
   pkg-config,
   makeWrapper,
   solana-platform-tools,
@@ -44,8 +44,8 @@ let
   version = solana-source.version;
   src = solana-source.src;
 
-  # Use Rust 1.84.1 as required by Agave
-  rust = rust-bin.stable."1.84.1".default;
+  # Use Rust 1.86.0 as required by Agave
+  rust = rust-bin.stable."1.86.0".default;
   rustPlatform = makeRustPlatform {
     cargo = rust;
     rustc = rust;
@@ -98,8 +98,8 @@ let
     NIX_OUTPATH_USED_AS_RANDOM_SEED = "aaaaaaaaaa";
 
     # Used by build.rs in the rocksdb-sys crate
-    ROCKSDB_LIB_DIR = "${rocksdb_8_11}/lib";
-    ROCKSDB_INCLUDE_DIR = "${rocksdb_8_11}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+    ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
 
     # For darwin systems
     CPPFLAGS = lib.optionals stdenv.isDarwin "-isystem ${lib.getDev libcxx}/include/c++/v1";

--- a/solana-platform-tools.nix
+++ b/solana-platform-tools.nix
@@ -12,7 +12,7 @@
   xz,
   zlib,
   system ? builtins.currentSystem,
-  version ? "1.45",
+  version ? "1.48",
 }:
 let
   systemMapping = {
@@ -24,6 +24,13 @@ let
   };
 
   versionMapping = {
+    "1.48" = {
+      x86_64-linux = "sha256-vHeOPs7B7WptUJ/mVvyt7ue+MqfqAsbwAHM+xlN/tgQ=";
+      aarch64-linux = "sha256-i3I9pwa+DyMJINFr+IucwytzEHdiRZU6r7xWHzppuR4=";
+      x86_64-darwin = "sha256-bXV4S8JeM4RJ7D9u+ruwtNFJ9aq01cFw80sprxB+Xng=";
+      aarch64-darwin = "sha256-ViXRoGlfn0aduNaZgsiXTcSIZO560DmFF5+kh3kYNIA=";
+      x86_64-windows = "sha256-hEVs9TPLX2YY2SBwt8qE8b700yznC71NHszz/zXdpZQ=";
+    };
     "1.45" = {
       x86_64-linux = "sha256-QGm7mOd3UnssYhPt8RSSRiS5LiddkXuDtWuakpak0Y0=";
       aarch64-linux = "sha256-UzOekFBdjtHJzzytmkQETd6Mrb+cdAsbZBA0kzc75Ws=";
@@ -91,7 +98,7 @@ stdenv.mkDerivation rec {
 
   # A bit ugly, but liblldb.so uses libedit.so.2 and nix provides libedit.so
   postFixup = lib.optionals stdenv.isLinux ''
-    patchelf --replace-needed libedit.so.2 libedit.so $out/bin/platform-tools-sdk/sbf/dependencies/platform-tools/llvm/lib/liblldb.so.18.1.7-rust-dev
+    patchelf --replace-needed libedit.so.2 libedit.so $out/bin/platform-tools-sdk/sbf/dependencies/platform-tools/llvm/lib/liblldb.so.19.1.7-rust-dev
   '';
 
   # We need to preserve metadata in .rlib, which might get stripped on macOS. See https://github.com/NixOS/nixpkgs/issues/218712

--- a/solana-platform-tools.nix
+++ b/solana-platform-tools.nix
@@ -6,6 +6,7 @@
   lib,
   libclang,
   libedit,
+  openssl,
   python310,
   solana-source,
   udev,
@@ -75,7 +76,7 @@ stdenv.mkDerivation rec {
     libclang.lib
     xz
     python310
-  ] ++ lib.optionals stdenv.isLinux [ udev ];
+  ] ++ lib.optionals stdenv.isLinux [ openssl udev ];
 
   installPhase = ''
     platformtools=$out/bin/platform-tools-sdk/sbf/dependencies/platform-tools

--- a/solana-source.nix
+++ b/solana-source.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 let
-  version = "2.2.3";
-  sha256 = "sha256-nRCamrwzoPX0cAEcP6p0t0t9Q41RjM6okupOPkJH5lQ=";
+  version = "2.3.7";
+  sha256 = "sha256-PZtnPBQbQwr5Ezogzv5ujALTaMcFAIZhPhaBQWt1jp8=";
 in
 {
   inherit version;


### PR DESCRIPTION
#### Problem

Solana mainnet-beta is now running v2.3, but this repo is still building v2.2.

#### Summary of changes

* Update the nixpkgs for rocksdb v9
* Update rust-overlay for Rust 1.86
* Update platform-tools to v1.48
* Update Solana sources to v2.3.7